### PR TITLE
Fix: Overhaul Codex-Manager.ps1 and update README for robust irm|iex …

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,12 +75,7 @@ If you prefer manual installation:
    ```powershell
    .\Install.ps1
    ```
-
-1. **Import Registry**: Right-click `Registry\Codex.reg` and select "Merge"
-2. **Set Execution Policy**:
-   ```powershell
-   Set-ExecutionPolicy RemoteSigned -Scope CurrentUser
-   ```
+   The `.\Install.ps1` script handles registry importation with corrected paths. Manual import of `Codex.reg` is not recommended as it contains placeholder paths. The script also sets the required PowerShell execution policy.
 
 ## Usage
 
@@ -108,20 +103,24 @@ Dynamic Boost analyzes your system every 10 seconds and:
 
 ## File Structure
 ```
-GhostMode/
-├── Scripts/
-│   ├── PowerManager.ps1      # Standard power plan switching
-│   ├── GameTurbo.ps1         # Ultimate gaming optimization
-│   ├── DynamicBoost.ps1      # Intelligent performance management
-│   ├── PingTest.ps1          # Network connectivity testing
-│   ├── ReduceMemory.ps1      # Memory optimization
-│   ├── CleanupTemp.ps1       # System cleanup
-│   ├── RoboCopy.ps1          # Advanced file copying
-│   └── RoboPaste.ps1         # Smart paste operations
+Plexus-Codex/
+├── Codex-Manager.ps1       # Main remote installer/uninstaller script
+├── Codex-Manager.bat       # Batch file wrapper for Codex-Manager.ps1
+├── Install.ps1             # Local installer script (for manual repo download)
+├── README.md               # This file
+├── Icons/
+│   ├── Source/             # Source PNG icons (white, for theming)
+│   └── Tinted/             # Output for themed ICO/PNG icons by IconTinter.ps1
 ├── Registry/
-│   └── GhostMode.reg         # Registry entries for context menu
-├── Install.ps1               # Installation script
-└── README.md                 # This file
+│   └── Codex.reg           # Registry entries (uses placeholders, modified by installer)
+├── Scripts/
+│   ├── Install-Codex.ps1   # Advanced installer (core logic, called by Codex-Manager)
+│   ├── Uninstall-Codex.ps1 # Uninstaller script
+│   ├── IconTinter.ps1      # Script to create themed icons
+│   ├── PowerManager.ps1    # Example utility script
+│   └── ...                 # Other PowerShell utility scripts
+└── Tools/
+    └── nircmd.exe          # NirCmd utility (downloaded by installer)
 ```
 
 ## Requirements
@@ -133,13 +132,15 @@ GhostMode/
 ## Uninstallation
 
 ### Automatic Uninstallation (Recommended)
-Run the uninstaller script as Administrator:
 ```powershell
-# Navigate to Codex directory
-cd "C:\Users\Marek\Plexus Codex\Codex\Scripts"
+# Recommended: Use the Codex Manager script
+irm https://raw.githubusercontent.com/Marek-Codex/Plexus-Codex/main/Codex-Manager.ps1 | iex -Uninstall
 
-# Run uninstaller
-.\Uninstall-Codex.ps1
+# Alternative (if you know your installation path):
+# 1. Navigate to your Codex installation directory (e.g., C:\ProgramData\Plexus\Codex or %LOCALAPPDATA%\Plexus\Codex)
+# 2. Open the 'Scripts' subfolder.
+# 3. Run PowerShell as Administrator in this folder and execute:
+#    .\Uninstall-Codex.ps1
 ```
 
 **Uninstaller Options:**


### PR DESCRIPTION
…functionality.

This commit addresses crashes and usability issues related to the `irm | iex` installation method.

1.  **`Codex-Manager.ps1` Overhaul:**
    *   The `Install-Codex` function within `Codex-Manager.ps1` now correctly downloads and executes the advanced installer script (`Scripts/Install-Codex.ps1`) instead of the basic root `Install.ps1`. This ensures that all dependencies are fetched, paths in `Codex.reg` are dynamically updated, icons are tinted, and the installation is placed in appropriate system locations (e.g., ProgramData).
    *   Ensured that necessary parameters (like `$GitHubRepo`, `$InstallPath`, `$UserInstall`) are correctly passed from `Codex-Manager.ps1` to `Scripts/Install-Codex.ps1`.
    *   Removed a hardcoded user-specific path from the `Find-CodexInstallation` helper function.
    *   The script now correctly provides interactive install/uninstall choices and handles `-Install` / `-Uninstall` parameters as intended for the `irm | iex` use case.

2.  **`README.md` Update:**
    *   Revised installation instructions to accurately reflect the usage of `Codex-Manager.ps1` as the primary entry point for `irm | iex`.
    *   Updated the "File Structure" section to match the actual project layout.
    *   Corrected "Uninstallation" instructions, guiding you to use `Codex-Manager.ps1 | iex -Uninstall` or to find the uninstaller in the dynamic installation path.
    *   Removed misleading advice about manual registry file merging, emphasizing script-based installation for path correction.

These changes should resolve the previously reported crashes and ensure a smooth, reliable experience for you when installing or managing Codex via the `irm | iex` method from GitHub.